### PR TITLE
Implement the get_erase_size API (based on address)

### DIFF
--- a/FlashIAPBlockDevice.cpp
+++ b/FlashIAPBlockDevice.cpp
@@ -151,6 +151,15 @@ bd_size_t FlashIAPBlockDevice::get_erase_size() const
     return erase_size;
 }
 
+bd_size_t FlashIAPBlockDevice::get_erase_size(bd_addr_t addr) const
+{
+    uint32_t erase_size = _flash.get_sector_size(_base + addr);
+
+    DEBUG_PRINTF("get_erase_size: %" PRIX32 "\r\n", erase_size);
+
+    return erase_size;
+}
+
 bd_size_t FlashIAPBlockDevice::size() const
 {
     DEBUG_PRINTF("size: %" PRIX64 "\r\n", _size);

--- a/FlashIAPBlockDevice.h
+++ b/FlashIAPBlockDevice.h
@@ -110,6 +110,14 @@ public:
      */
     virtual bd_size_t get_erase_size() const;
 
+    /** Get the size of an erasable block given address
+     *
+     *  @param addr     Address within the erasable block
+     *  @return         Size of an erasable block in bytes
+     *  @note Must be a multiple of the program size
+     */
+    virtual bd_size_t get_erase_size(bd_addr_t addr) const;
+
     /** Get the total size of the underlying device
      *
      *  @return         Size of the underlying device in bytes


### PR DESCRIPTION
Description:
Implemented the `get_erase_size(bd_addr_t addr)` API (one depending on address).
Fixes the warning described in issue [#35](https://github.com/ARMmbed/storage-selector/issues/35) of storage_selector repo.