### PR TITLE
Adding deprecation warning for mbed-os 5.10

### DIFF
--- a/FlashIAPBlockDevice.cpp
+++ b/FlashIAPBlockDevice.cpp
@@ -23,6 +23,12 @@
 
 #include <inttypes.h>
 
+/* Started from version 5.10.0 FlashIAPBlockDevice external repo is depricated. 
+   please use the FlashIAPBlockDevice component inside mbed-os.*/
+#if defined(MBED_MAJOR_VERSION) && MBED_MAJOR_VERSION >= 5 && (MBED_VERSION >= MBED_ENCODE_VERSION(5,10,0))
+#error "Started from version 5.10.0 FlashIAPBlockDevice external repo is depricated. please use the FlashIAPBlockDevice component inside mbed-os."
+#endif
+
 #define FLASHIAP_READ_SIZE 1
 
 // Debug available

--- a/FlashIAPBlockDevice.cpp
+++ b/FlashIAPBlockDevice.cpp
@@ -23,10 +23,10 @@
 
 #include <inttypes.h>
 
-/* Started from version 5.10.0 FlashIAPBlockDevice external repo is depricated. 
+/* Started from version 5.10.0 FlashIAPBlockDevice external repo is deprecated. 
    please use the FlashIAPBlockDevice component inside mbed-os.*/
 #if defined(MBED_MAJOR_VERSION) && MBED_MAJOR_VERSION >= 5 && (MBED_VERSION >= MBED_ENCODE_VERSION(5,10,0))
-#error "Started from version 5.10.0 FlashIAPBlockDevice external repo is depricated. please use the FlashIAPBlockDevice component inside mbed-os."
+#error "Started from version 5.10.0 FlashIAPBlockDevice external repo is deprecated. please use the FlashIAPBlockDevice component inside mbed-os."
 #endif
 
 #define FLASHIAP_READ_SIZE 1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Warning
 Starting from mbed-os 5.10 this repository is deprecated. 
-Please refer to mbed-os 5.10 documentation for more detail on how to enable FLASHIAP support.
+Please refer to mbed-os 5.10 [documentation](https://github.com/ARMmbed/mbed-os-5-docs/blob/development/docs/api/storage/FlashIAPBlockDevice.md) and [code](https://github.com/ARMmbed/mbed-os/tree/master/components/storage/blockdevice/COMPONENT_FLASHIAP) for more detail on how to enable FLASHIAP support.
 
 # Block Device driver build on top of FlashIAP API
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Warning
+Starting from mbed-os 5.10 this repository is deprecated. 
+Please refer to mbed-os 5.10 documentation for more detail on how to enable FLASHIAP support.
+
 # Block Device driver build on top of FlashIAP API
 
 ## Warning 


### PR DESCRIPTION
Starting mbed-os 5.10 the SD driver has moved into mbed-os.
Therefore this PR is adding a warning in the SD documentation for the incoming depreciation. 

This PR is dependent on PR #7774
https://github.com/ARMmbed/mbed-os/pull/7774
