### PR TITLE
Revert "Merge pull request #3 from ARMmbed/david_init_changes"

### DIFF
--- a/FlashIAPBlockDevice.h
+++ b/FlashIAPBlockDevice.h
@@ -22,6 +22,14 @@
 #include "BlockDevice.h"
 #include <mbed.h>
 
+#ifndef MBED_CONF_FLASHIAP_BLOCK_DEVICE_BASE_ADDRESS
+#error flashiap-block-device.base-address not set
+#endif
+
+#ifndef MBED_CONF_FLASHIAP_BLOCK_DEVICE_SIZE
+#error flashiap-block-device.size not set
+#endif
+
 /** BlockDevice using the FlashIAP API
  *
  *  @code
@@ -31,13 +39,14 @@
  */
 class FlashIAPBlockDevice : public BlockDevice {
 public:
-    /** Creates a FlashIAPBlockDevice **/
-    FlashIAPBlockDevice();
-
-    MBED_DEPRECATED("Please use default constructor instead")
-    FlashIAPBlockDevice(uint32_t address, uint32_t size = 0);
-
-    virtual ~FlashIAPBlockDevice();
+    /** Creates a FlashIAPBlockDevice, starting at the given address and
+     *  with a certain size.
+     *
+     *  @param address  Starting address for the BlockDevice
+     *  @param size     Maximum size allocated to this BlockDevice
+     */
+    FlashIAPBlockDevice(uint32_t address = MBED_CONF_FLASHIAP_BLOCK_DEVICE_BASE_ADDRESS,
+                        uint32_t size = MBED_CONF_FLASHIAP_BLOCK_DEVICE_SIZE);
 
     /** Initialize a block device
      *

--- a/README.md
+++ b/README.md
@@ -6,13 +6,27 @@ This driver is **EXPERIMENTAL** and improper usage could kill your board's flash
 This driver should only be used on platforms where the FlashIAP implementation is using external flash or in conjunction with a filesystem with wear leveling, that can operate on a page size granularity.
 
 Additional concerns:
+- The BlockDevice API assumes a uniform erase size so the underlying flash must also have uniform sectors.
 - The FlashIAP may freeze code execution for a long period of time while writing to flash. Not even high-priority irqs will be allowed to run, which may interrupt background processes.
 
 
 ## Configuration
-None.
+
+The driver must be configured with the starting address for the internal flash area reserved for the block device and it's size in bytes. In the application's `mbed_app.json`, add the following lines:
+
+```json
+{
+    "target_overrides": {
+        "K64F": {
+            "flashiap-block-device.base-address": "<internal flash address where the block device starts>",
+            "flashiap-block-device.size": "<number of bytes allocated to the internal flash block device>"
+        }
+    }
+}
+```
+
 
 ## Tested on
 
-* K82F
+* Realtek RTL8195AM
 * K64F

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -1,0 +1,19 @@
+{
+    "name": "flashiap-block-device",
+    "config": {
+        "base-address": {
+            "help": "Base address for the block device on the external flash.",
+            "value": "0xFFFFFFFF"
+        },
+        "size": {
+            "help": "Memory allocated for block device.",
+            "value": "0"
+        }
+    },
+    "target_overrides": {
+        "REALTEK_RTL8195AM": {
+            "base-address": "0x1C0000",
+            "size": "0x40000"
+        }
+    }
+}


### PR DESCRIPTION
We're getting reports already that this is breaking everything that depends on flashiap-driver. We need to revert this for now until the necessary changes are in place to migrate without breaking user code.

@davidsaada, feel free to reopen another PR to remove the flash offsets (It may need to be against mbed-os). But we'll need to make sure users have a way to update.

Note! This only reverts the change to address logic. Reference counting
is kept due to external dependencies on the functionality.

cc @marcuschangarm, @bridadan, @davidsaada, @yossi2le, @deepikabhavnani